### PR TITLE
Added "captureOnly" flag to Move class

### DIFF
--- a/src/main/java/touro/chess/Move.java
+++ b/src/main/java/touro/chess/Move.java
@@ -15,6 +15,12 @@ public class Move {
      */
     private final boolean captureOnly;
 
+    public Move(Location from,
+                Location to,
+                boolean jump) {
+        this(from, to, jump, false);
+    }
+
     public Move(
             Location from,
             Location to,

--- a/src/main/java/touro/chess/Move.java
+++ b/src/main/java/touro/chess/Move.java
@@ -10,13 +10,20 @@ public class Move {
      */
     private final boolean jump;
 
+    /**
+     * Specifies that this move can only be done to capture another piece (Pawn moving diagonally)
+     */
+    private final boolean captureOnly;
+
     public Move(
             Location from,
             Location to,
-            boolean jump) {
+            boolean jump,
+            boolean captureOnly) {
         this.from = from;
         this.to = to;
         this.jump = jump;
+        this.captureOnly = captureOnly;
     }
 
     public Location getFrom() {
@@ -31,12 +38,17 @@ public class Move {
         return jump;
     }
 
+    public boolean isCaptureOnly() {
+        return captureOnly;
+    }
+
     @Override
     public String toString() {
         return "Move{" +
                 "from=" + from +
                 ", to=" + to +
                 ", jump=" + jump +
+                ", captureOnly=" + captureOnly +
                 '}';
     }
 }


### PR DESCRIPTION
The `PawnPiece` has legal moves, but those moves are only legal if they are capturing pieces. 
So a flag has been added to the `Move` class to specify this and can be evaluated correctly `Board.isLegal(Move)`